### PR TITLE
Semgrep rule for webview setAllowFileAccess

### DIFF
--- a/mobsfscan/rules/semgrep/webview/webview_file_access.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_file_access.yaml
@@ -4,10 +4,6 @@ rules:
       - pattern-either:
           - pattern: |
               $WB.setAllowFileAccess(true);
-          - pattern: |
-              $X = true;
-              ...
-              $WB.setAllowFileAccess($X);
     message: >-
       WebView File System Access is enabled. An attacker able to inject script into a WebView, could exploit the opportunity to access local resources.
     languages:

--- a/mobsfscan/rules/semgrep/webview/webview_file_access.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_file_access.yaml
@@ -1,5 +1,5 @@
 rules:
-  - id: webview_setAllowFileAccess
+  - id: webview_set_allow_file_access
     patterns:
       - pattern-either:
           - pattern: |
@@ -7,15 +7,15 @@ rules:
           - pattern: |
               $X = true;
               ...
-              $WB.setAllowFileAccess($SX);
+              $WB.setAllowFileAccess($X);
     message: >-
       WebView File System Access is enabled. An attacker able to inject script into a WebView, could exploit the opportunity to access local resources.
     languages:
       - java
-    severity: ERROR
+    severity: WARNING
     metadata:
-      cwe: N/A
+      cwe: cwe-73
       owasp-mobile: m7
-      masvs: resilience-6.6
+      masvs: platform-6
       reference: >-
-        https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md
+        https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md/#testing-webview-protocol-handlers-mstg-platform-6

--- a/mobsfscan/rules/semgrep/webview/webview_file_access.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_file_access.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: webview_setAllowFileAccess
+    patterns:
+      - pattern-either:
+          - pattern: |
+              $WB.setAllowFileAccess(true);
+          - pattern: |
+              $X = true;
+              ...
+              $WB.setAllowFileAccess($SX);
+    message: >-
+      WebView File System Access is enabled. An attacker able to inject script into a WebView, could exploit the opportunity to access local resources.
+    languages:
+      - java
+    severity: ERROR
+    metadata:
+      cwe: N/A
+      owasp-mobile: m7
+      masvs: resilience-6.6
+      reference: >-
+        https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md

--- a/tests/assets/rules/semgrep/webview/webview_file_access.java
+++ b/tests/assets/rules/semgrep/webview/webview_file_access.java
@@ -1,0 +1,30 @@
+class Webview extends WebViewClient {
+        public void vulnerableMethodSetAllowFileAccess() {
+                WebView web = (WebView) findViewById(R.id.webview);
+        }
+        public void vulnerableMethodSetAllowFileAccess2() {
+                WebView web = (WebView) findViewById(R.id.webview);
+                WebSettings webSettings = web.getSettings();
+                webSettings.setWebContentsDebuggingEnabled(true);
+                // ruleid:webview_set_allow_file_access
+                webSettings.setAllowFileAccess(true);
+        }
+
+         public void vulnerableMethodSetAllowFileAccess1() {
+                boolean fileAccess = true;
+                WebView web = (WebView) findViewById(R.id.webview);
+                WebSettings webSettings = web.getSettings();
+                webSettings.setWebContentsDebuggingEnabled(true);
+                // ruleid:webview_set_allow_file_access
+                webSettings.setAllowFileAccess(fileAccess);
+        }
+
+          public void vulnerableMethodSetAllowFileAccessok() {
+                boolean fileAccess = false;
+                WebView web = (WebView) findViewById(R.id.webview);
+                WebSettings webSettings = web.getSettings();
+                webSettings.setWebContentsDebuggingEnabled(true);
+                // ok: webview_set_allow_file_access
+                webSettings.setAllowFileAccess(fileAccess);
+        }
+}


### PR DESCRIPTION
## Description
Semgrep rule for webview setAllowFileAccess. If enabled could end up allowing access to local resources, if an attacker is able to inject scripts.

## Testing

Tested locally against a java file.
```
class Webview extends WebViewClient {
        public void vulnerableMethodSetAllowFileAccess() {
                WebView web = (WebView) findViewById(R.id.webview);
        }

        public void vulnerableMethodSetAllowFileAccess2() {
                WebView web = (WebView) findViewById(R.id.webview);
                WebSettings webSettings = web.getSettings();
                webSettings.setWebContentsDebuggingEnabled(true);
                webSettings.setAllowFileAccess(true);
        }
}

```

