### PR TITLE
Add severity-filter feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ A `.mobsf` file in the root of the source code directory allows you to configure
   - android_certificate_pinning
   - android_root_detection
   - android_certificate_transparency
+
+  severity-filter:
+  - WARNING
+  - ERROR
 ```
 ## Suppress Findings
 

--- a/mobsfscan/mobsfscan.py
+++ b/mobsfscan/mobsfscan.py
@@ -27,6 +27,7 @@ class MobSFScan:
             'ignore_extensions': self.conf['ignore_extensions'],
             'ignore_paths': self.conf['ignore_paths'],
             'ignore_rules': self.conf['ignore_rules'],
+            'severity_filter': self.conf['severity_filter'],
             'show_progress': not json,
         }
         self.paths = paths
@@ -87,6 +88,7 @@ class MobSFScan:
         self.format_pattern(results.get('pattern_matcher'))
         self.missing_controls()
         self.post_ignore_rules()
+        self.post_ignore_rules_by_severity()
         self.post_ignore_files()
 
     def format_semgrep(self, sgrep_output):
@@ -150,6 +152,17 @@ class MobSFScan:
         for rule_id in self.options['ignore_rules']:
             if rule_id in self.result['results']:
                 del self.result['results'][rule_id]
+
+    def post_ignore_rules_by_severity(self):
+        """Filter findings by rule severity."""
+        del_keys = set()
+        for rule_id, details in self.result['results'].items():
+            issue_severity = details.get('metadata').get('severity')
+            if issue_severity not in self.options['severity_filter']:
+                del_keys.add(rule_id)
+        for rid in del_keys:
+            if rid in self.result['results']:
+                del self.result['results'][rid]
 
     def suppress_pm_comments(self, obj, rule_id):
         """Suppress pattern matcher."""

--- a/mobsfscan/settings.py
+++ b/mobsfscan/settings.py
@@ -33,3 +33,9 @@ BEST_PRACTICES_DIR = (
     BASE_DIR / 'rules' / 'semgrep' / 'best_practices'
 )
 BEST_PRACTICES_FILE = 'best_practices.yaml'
+
+SEVERITY_FILTER = (
+    'INFO',
+    'WARNING',
+    'ERROR'
+)

--- a/mobsfscan/settings.py
+++ b/mobsfscan/settings.py
@@ -37,5 +37,5 @@ BEST_PRACTICES_FILE = 'best_practices.yaml'
 SEVERITY_FILTER = (
     'INFO',
     'WARNING',
-    'ERROR'
+    'ERROR',
 )

--- a/mobsfscan/utils.py
+++ b/mobsfscan/utils.py
@@ -17,7 +17,7 @@ def get_config(base_path, config_file):
         'ignore_extensions': config.IGNORE_EXTENSIONS,
         'ignore_paths': config.IGNORE_PATHS,
         'ignore_rules': set(),
-        'severity_threshold': config.SEVERITY_FILTER,
+        'severity_filter': config.SEVERITY_FILTER,
     }
     if config_file:
         cfile = Path(config_file)

--- a/mobsfscan/utils.py
+++ b/mobsfscan/utils.py
@@ -17,6 +17,7 @@ def get_config(base_path, config_file):
         'ignore_extensions': config.IGNORE_EXTENSIONS,
         'ignore_paths': config.IGNORE_PATHS,
         'ignore_rules': set(),
+        'severity_threshold': config.SEVERITY_FILTER,
     }
     if config_file:
         cfile = Path(config_file)
@@ -31,12 +32,15 @@ def get_config(base_path, config_file):
         usr_ignore_files = root.get('ignore-filenames')
         usr_igonre_paths = root.get('ignore-paths')
         usr_ignore_rules = root.get('ignore-rules')
+        usr_severity_filter = root.get('severity-filter')
         if usr_ignore_files:
             options['ignore_filenames'].update(usr_ignore_files)
         if usr_igonre_paths:
             options['ignore_paths'].update(usr_igonre_paths)
         if usr_ignore_rules:
             options['ignore_rules'].update(usr_ignore_rules)
+        if usr_severity_filter:
+            options['severity_filter'] = usr_severity_filter
     return options
 
 


### PR DESCRIPTION
Resolve https://github.com/MobSF/mobsfscan/issues/9

Running scan without `.mobsf` file:

```
❯ docker run -v $(pwd):/app mobsfscan /app --json | jq '.results[].metadata.severity'
"INFO"
"WARNING"
"INFO"
"INFO"
"INFO"
"INFO"
"INFO"
```

Add `.mobsf` file with content:
```
---
- severity-filter:
  - WARNING
```
 
And got only `WARNING` result:
```
❯ docker run -v $(pwd):/app mobsfscan /app --json | jq '.results[].metadata.severity'
"WARNING"
```