### PR TITLE
remove columns

### DIFF
--- a/mobsfscan/formatters/sonarqube.py
+++ b/mobsfscan/formatters/sonarqube.py
@@ -20,8 +20,6 @@ def get_sonarqube_issue(mobsfscan_issue):
             text_range = {
                 'startLine': file['match_lines'][0],
                 'endLine': file['match_lines'][1],
-                'startColumn': file['match_position'][0],
-                'endColumn': file['match_position'][1],
             }
             location = {
                 'message': issue_data['description'],


### PR DESCRIPTION
scanner.scan() results is retrieving wrong numbers for the columns, until we find the issue with the columns we can remove this (columns are not mandatory)