### PR TITLE
Include CWE information in rule tags for sarif output

### DIFF
--- a/mobsfscan/formatters/sarif.py
+++ b/mobsfscan/formatters/sarif.py
@@ -96,6 +96,9 @@ def create_result(path, rule_id, issue_dict, rules, rule_indices):
             id=rule_id,
             name=get_rule_name(rule_id),
             help_uri=doc,
+            properties={
+                'tags': ['security', 'external/cwe' + issue_dict['metadata']['cwe'].split(':')[0].lower()]
+            }
         )
         rule_index = len(rules)
         rules[rule_id] = rule


### PR DESCRIPTION
While CWE-related metadata is included within the source code rules, it does not make its way into the SARIF results. By making this change, if SARIF results are uploaded to GitHub Code Scanning, an alert is decorated with the appropriate CWE, as well as CWEs become tag that can be searched.

![image](https://user-images.githubusercontent.com/107562400/194098455-d18cc484-9e34-4bd1-abd4-182c75aa8fc1.png)