### PR TITLE
Include `security-severity` as property of each rule

### DIFF
--- a/mobsfscan/formatters/sarif.py
+++ b/mobsfscan/formatters/sarif.py
@@ -93,12 +93,17 @@ def create_result(path, rule_id, issue_dict, rules, rule_indices):
             doc = ('https://mobile-security.gitbook.io/'
                    'mobile-security-testing-guide/')
         cwe_id = issue_dict['metadata']['cwe'].split(':')[0].lower()
+        security_severity = issue_dict['metadata'].get('security-severity')
+        if not security_severity:
+            security_severity = 6.5
+
         rule = om.ReportingDescriptor(
             id=rule_id,
             name=get_rule_name(rule_id),
             help_uri=doc,
             properties={
                 'tags': ['security', f'external/cwe/{cwe_id}'],
+                'security-severity': f'{security_severity}',
             },
         )
         rule_index = len(rules)

--- a/mobsfscan/rules/patterns/android/kotlin/best_practices.yaml
+++ b/mobsfscan/rules/patterns/android/kotlin/best_practices.yaml
@@ -13,6 +13,7 @@
   input_case: exact
   metadata:
     cwe: cwe-353
+    security-severity: 7.5
     owasp-mobile: m8
     masvs: resilience-1
     reference: >-
@@ -30,6 +31,7 @@
   input_case: exact
   metadata:
     cwe: cwe-200
+    security-severity: 6.5
     owasp-mobile: m2
     masvs: storage-9
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#finding-sensitive-information-in-auto-generated-screenshots-mstg-storage-9
@@ -49,6 +51,7 @@
   input_case: exact
   metadata:
     cwe: cwe-919
+    security-severity: 
     owasp-mobile: m8
     masvs: resilience-1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md#testing-root-detection-mstg-resilience-1
@@ -60,6 +63,7 @@
   input_case: exact
   metadata:
     cwe: cwe-200
+    security-severity: 6.5
     owasp-mobile: m1
     masvs: platform-9
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#testing-for-overlay-attacks-mstg-platform-9
@@ -77,6 +81,7 @@
   input_case: exact
   metadata:
     cwe: cwe-295
+    security-severity: 7.5
     owasp-mobile: m3
     masvs: network-4
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#testing-custom-certificate-stores-and-certificate-pinning-mstg-network-4
@@ -97,6 +102,7 @@
   input_case: exact
   metadata:
     cwe: cwe-295
+    security-severity: 7.5
     owasp-mobile: m3
     masvs: network-4
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#testing-custom-certificate-stores-and-certificate-pinning-mstg-network-4

--- a/mobsfscan/rules/patterns/android/kotlin/best_practices.yaml
+++ b/mobsfscan/rules/patterns/android/kotlin/best_practices.yaml
@@ -51,7 +51,7 @@
   input_case: exact
   metadata:
     cwe: cwe-919
-    security-severity: 
+    security-severity: ''
     owasp-mobile: m8
     masvs: resilience-1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md#testing-root-detection-mstg-resilience-1

--- a/mobsfscan/rules/patterns/android/kotlin/best_practices.yaml
+++ b/mobsfscan/rules/patterns/android/kotlin/best_practices.yaml
@@ -13,7 +13,7 @@
   input_case: exact
   metadata:
     cwe: cwe-353
-    security-severity: 7.5
+    security-severity: "7.5"
     owasp-mobile: m8
     masvs: resilience-1
     reference: >-
@@ -31,7 +31,7 @@
   input_case: exact
   metadata:
     cwe: cwe-200
-    security-severity: 6.5
+    security-severity: "6.5"
     owasp-mobile: m2
     masvs: storage-9
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#finding-sensitive-information-in-auto-generated-screenshots-mstg-storage-9
@@ -63,7 +63,7 @@
   input_case: exact
   metadata:
     cwe: cwe-200
-    security-severity: 6.5
+    security-severity: "6.5"
     owasp-mobile: m1
     masvs: platform-9
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#testing-for-overlay-attacks-mstg-platform-9
@@ -81,7 +81,7 @@
   input_case: exact
   metadata:
     cwe: cwe-295
-    security-severity: 7.5
+    security-severity: "7.5"
     owasp-mobile: m3
     masvs: network-4
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#testing-custom-certificate-stores-and-certificate-pinning-mstg-network-4
@@ -102,7 +102,7 @@
   input_case: exact
   metadata:
     cwe: cwe-295
-    security-severity: 7.5
+    security-severity: "7.5"
     owasp-mobile: m3
     masvs: network-4
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#testing-custom-certificate-stores-and-certificate-pinning-mstg-network-4

--- a/mobsfscan/rules/patterns/android/kotlin/kotlin_rules.yaml
+++ b/mobsfscan/rules/patterns/android/kotlin/kotlin_rules.yaml
@@ -8,6 +8,7 @@
   input_case: exact
   metadata:
     cwe: cwe-919
+    security-severity:
     owasp-mobile: m1
     masvs: storage-7
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#checking-for-sensitive-data-disclosure-through-the-user-interface-mstg-storage-7
@@ -28,14 +29,15 @@
     owasp-mobile: m3
     masvs: network-3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#android-network-apis
+    security-severity: 7.5
 - id: android_kotlin_webview_external
   message: >-
     WebView load files from external storage. Files in external storage can be
     modified by any application.
   type: RegexAnd
   pattern:
-    - \.loadUrl\(.*getExternalStorageDirectory\(
-    - webkit\.WebView
+  - \.loadUrl\(.*getExternalStorageDirectory\(
+  - webkit\.WebView
   severity: ERROR
   input_case: exact
   metadata:
@@ -43,6 +45,7 @@
     owasp-mobile: m1
     masvs: platform-6
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#static-analysis-7
+    security-severity: 9.8
 - id: android_kotlin_insecure_random
   message: The App uses an insecure Random Number Generator.
   type: Regex
@@ -54,6 +57,7 @@
     owasp-mobile: m5
     masvs: crypto-6
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#weak-random-number-generators
+    security-severity: 8.8
 - id: android_kotlin_logging
   message: The App logs information. Sensitive information should never be logged.
   type: Regex
@@ -65,14 +69,15 @@
     owasp-mobile: m1
     masvs: storage-3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#logs
+    security-severity: 7.5
 - id: android_kotlin_webview
   message: >-
     Insecure WebView Implementation. Execution of user controlled code in
     WebView is a critical Security Hole.
   type: RegexAnd
   pattern:
-    - setJavaScriptEnabled\(true\)
-    - \.addJavascriptInterface\(
+  - setJavaScriptEnabled\(true\)
+  - \.addJavascriptInterface\(
   severity: WARNING
   input_case: exact
   metadata:
@@ -80,12 +85,13 @@
     owasp-mobile: m1
     masvs: platform-7
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#testing-javascript-execution-in-webviews-mstg-platform-5
+    security-severity: 9.8
 - id: android_kotlin_webview_debug
   message: Remote WebView debugging is enabled.
   type: RegexAnd
   pattern:
-    - \.setWebContentsDebuggingEnabled\(true\)
-    - WebView
+  - \.setWebContentsDebuggingEnabled\(true\)
+  - WebView
   severity: ERROR
   input_case: exact
   metadata:
@@ -93,14 +99,15 @@
     owasp-mobile: m1
     masvs: resilience-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md#testing-anti-debugging-detection-mstg-resilience-2
+    security-severity: 7.2
 - id: android_kotlin_webview_ignore_ssl
   message: >-
     Insecure WebView Implementation. WebView ignores SSL Certificate errors and
     accept any SSL Certificate. This application is vulnerable to MITM attacks
   type: RegexAnd
   pattern:
-    - onReceivedSslError\(WebView
-    - \.proceed\(\);
+  - onReceivedSslError\(WebView
+  - \.proceed\(\);
   severity: ERROR
   input_case: exact
   metadata:
@@ -108,6 +115,7 @@
     owasp-mobile: m3
     masvs: network-3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#webview-server-certificate-verification
+    security-severity: 7.5
 - id: android_kotlin_sql_raw_query
   message: >-
     App uses SQLite Database and execute raw SQL query. Untrusted user input in
@@ -115,9 +123,9 @@
     be encrypted and written to the database.
   type: RegexAndOr
   pattern:
-    - android\.database\.sqlite
-    - - rawQuery\(
-      - execSQL\(
+  - android\.database\.sqlite
+  - - rawQuery\(
+    - execSQL\(
   severity: WARNING
   input_case: exact
   metadata:
@@ -125,21 +133,23 @@
     owasp-mobile: m7
     masvs: platform-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04h-Testing-Code-Quality.md#injection-flaws-mstg-arch-2-and-mstg-platform-2
+    security-severity: 9.8
 - id: android_kotlin_jackson_deserialize
   message: >-
     The app uses jackson deserialization library. Deserialization of untrusted
     input can result in arbitrary code execution.
   type: RegexAnd
   pattern:
-    - com\.fasterxml\.jackson\.databind\.ObjectMapper
-    - \.enableDefaultTyping\(
+  - com\.fasterxml\.jackson\.databind\.ObjectMapper
+  - \.enableDefaultTyping\(
   severity: ERROR
   input_case: exact
   metadata:
     cwe: cwe-502
     owasp-mobile: m7
     masvs: platform-8
-    reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#testing-object-persistence-mstg-platform-8 
+    reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#testing-object-persistence-mstg-platform-8
+    security-severity: 9.8
 - id: android_kotlin_aes_ecb
   message: >-
     The App uses ECB mode in Cryptographic encryption algorithm. ECB mode is
@@ -154,6 +164,7 @@
     owasp-mobile: m5
     masvs: crypto-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#weak-block-cipher-mode
+    security-severity: 7.5
 - id: android_kotlin_aes_ecb_default
   message: >-
     Calling Cipher.getInstance("AES") will return AES ECB mode by default. ECB mode is
@@ -168,11 +179,12 @@
     owasp-mobile: m5
     masvs: crypto-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#weak-block-cipher-mode
+    security-severity: 7.5
 - id: cbc_kotlin_padding_oracle
   message: The App uses the encryption mode CBC with PKCS5/PKCS7 padding. This configuration is vulnerable to padding oracle attacks.
   pattern:
-    - \.getInstance\(.*\/CBC\/PKCS5Padding
-    - \.getInstance\(.*\/CBC\/PKCS7Padding
+  - \.getInstance\(.*\/CBC\/PKCS5Padding
+  - \.getInstance\(.*\/CBC\/PKCS7Padding
   type: RegexOr
   severity: ERROR
   input_case: exact
@@ -181,6 +193,7 @@
     owasp-mobile: m5
     cwe: cwe-649
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
+    security-severity: 6.4
 - id: android_kotlin_rsa_no_oaep
   message: >-
     This App uses RSA Crypto without OAEP padding. The purpose of the padding
@@ -195,12 +208,13 @@
     owasp-mobile: m5
     masvs: crypto-3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#mobile-app-cryptography
+    security-severity: 7.5
 - id: android_kotlin_world_writable
   message: The file is World Writable. Any App can write to the file
   type: RegexOr
   pattern:
-    - MODE_WORLD_WRITABLE
-    - 'openFileOutput\(\s*".+"\s*,\s*2\s*\)'
+  - MODE_WORLD_WRITABLE
+  - 'openFileOutput\(\s*".+"\s*,\s*2\s*\)'
   severity: WARNING
   input_case: exact
   metadata:
@@ -208,12 +222,13 @@
     owasp-mobile: m2
     masvs: storage-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#testing-local-storage-for-sensitive-data-mstg-storage-1-and-mstg-storage-2
+    security-severity: 7.8
 - id: android_kotlin_world_readable
   message: The file is World Readable. Any App can read from the file
   type: RegexOr
   pattern:
-    - MODE_WORLD_READABLE
-    - 'openFileOutput\(\s*".+"\s*,\s*1\s*\)'
+  - MODE_WORLD_READABLE
+  - 'openFileOutput\(\s*".+"\s*,\s*1\s*\)'
   severity: WARNING
   input_case: exact
   metadata:
@@ -221,6 +236,7 @@
     owasp-mobile: m2
     masvs: storage-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#testing-local-storage-for-sensitive-data-mstg-storage-1-and-mstg-storage-2
+    security-severity: 7.8
 - id: android_kotlin_world_read_write
   message: The file is World Readable and Writable. Any App can read/write to the file
   type: Regex
@@ -232,11 +248,12 @@
     owasp-mobile: m2
     masvs: storage-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#testing-local-storage-for-sensitive-data-mstg-storage-1-and-mstg-storage-2
+    security-severity: 7.8
 - id: android_kotlin_weak_hash
   message: Weak Hash algorithm used. The hash algorithm is known to have hash collisions.
   pattern:
-    - \.getInstance\(.*md4
-    - \.getInstance\(.*MD4
+  - \.getInstance\(.*md4
+  - \.getInstance\(.*MD4
   type: RegexOr
   input_case: exact
   severity: WARNING
@@ -245,32 +262,34 @@
     owasp-mobile: m5
     cwe: cwe-327
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
+    security-severity: 7.5
 - id: android_kotlin_weak_ciphers
   message: Weak Encryption algorithm used
   severity: ERROR
   type: RegexOr
   input_case: exact
   pattern:
-    - \.getInstance\(.*rc2
-    - \.getInstance\(.*RC2
-    - \.getInstance\(.*rc4
-    - \.getInstance\(.*RC4
-    - \.getInstance\(.*blowfish
-    - \.getInstance\(.*BLOWFISH
-    - Cipher\.getInstance\(.*DES
-    - Cipher\.getInstance\(.*des
+  - \.getInstance\(.*rc2
+  - \.getInstance\(.*RC2
+  - \.getInstance\(.*rc4
+  - \.getInstance\(.*RC4
+  - \.getInstance\(.*blowfish
+  - \.getInstance\(.*BLOWFISH
+  - Cipher\.getInstance\(.*DES
+  - Cipher\.getInstance\(.*des
   metadata:
     cwe: cwe-327
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
+    security-severity: 7.5
 - id: android_kotlin_md5
   message: MD5 is a weak hash known to have hash collisions.
   type: RegexOr
   pattern:
-      - \.getInstance\(.*MD5
-      - \.getInstance\(.*md5
-      - DigestUtils\.md5\(
+  - \.getInstance\(.*MD5
+  - \.getInstance\(.*md5
+  - DigestUtils\.md5\(
   input_case: exact
   severity: WARNING
   metadata:
@@ -278,22 +297,24 @@
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
+    security-severity: 7.5
 - id: android_kotlin_sha1
   message: SHA-1 is a weak hash known to have hash collisions.
   type: RegexOr
   input_case: exact
   severity: WARNING
   pattern:
-    - \.getInstance\(.*SHA-1
-    - \.getInstance\(.*sha-1
-    - \.getInstance\(.*SHA1
-    - \.getInstance\(.*sha1
-    - DigestUtils\.sha\(
+  - \.getInstance\(.*SHA-1
+  - \.getInstance\(.*sha-1
+  - \.getInstance\(.*SHA1
+  - \.getInstance\(.*sha1
+  - DigestUtils\.sha\(
   metadata:
     cwe: cwe-327
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
+    security-severity: 7.5
 - id: android_kotlin_weak_iv
   message: >-
     The App may use weak IVs like "0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00" or
@@ -302,8 +323,8 @@
     attack.
   input_case: exact
   pattern:
-    - '0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00'
-    - '0x01,0x02,0x03,0x04,0x05,0x06,0x07'
+  - '0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00'
+  - '0x01,0x02,0x03,0x04,0x05,0x06,0x07'
   severity: WARNING
   type: RegexOr
   metadata:
@@ -311,6 +332,7 @@
     masvs: crypto-5
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#mobile-app-cryptography
+    security-severity: 7.5
 - id: android_kotlin_hardcoded
   message: >-
     Files may contain hardcoded sensitive information like usernames,
@@ -325,3 +347,4 @@
     cwe: cwe-798
     owasp-mobile: m9
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example
+    security-severity: 9.8

--- a/mobsfscan/rules/patterns/android/kotlin/kotlin_rules.yaml
+++ b/mobsfscan/rules/patterns/android/kotlin/kotlin_rules.yaml
@@ -8,7 +8,7 @@
   input_case: exact
   metadata:
     cwe: cwe-919
-    security-severity:
+    security-severity: ''
     owasp-mobile: m1
     masvs: storage-7
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#checking-for-sensitive-data-disclosure-through-the-user-interface-mstg-storage-7

--- a/mobsfscan/rules/patterns/android/kotlin/kotlin_rules.yaml
+++ b/mobsfscan/rules/patterns/android/kotlin/kotlin_rules.yaml
@@ -36,8 +36,8 @@
     modified by any application.
   type: RegexAnd
   pattern:
-  - \.loadUrl\(.*getExternalStorageDirectory\(
-  - webkit\.WebView
+    - \.loadUrl\(.*getExternalStorageDirectory\(
+    - webkit\.WebView
   severity: ERROR
   input_case: exact
   metadata:
@@ -76,8 +76,8 @@
     WebView is a critical Security Hole.
   type: RegexAnd
   pattern:
-  - setJavaScriptEnabled\(true\)
-  - \.addJavascriptInterface\(
+    - setJavaScriptEnabled\(true\)
+    - \.addJavascriptInterface\(
   severity: WARNING
   input_case: exact
   metadata:
@@ -90,8 +90,8 @@
   message: Remote WebView debugging is enabled.
   type: RegexAnd
   pattern:
-  - \.setWebContentsDebuggingEnabled\(true\)
-  - WebView
+    - \.setWebContentsDebuggingEnabled\(true\)
+    - WebView
   severity: ERROR
   input_case: exact
   metadata:
@@ -106,8 +106,8 @@
     accept any SSL Certificate. This application is vulnerable to MITM attacks
   type: RegexAnd
   pattern:
-  - onReceivedSslError\(WebView
-  - \.proceed\(\);
+    - onReceivedSslError\(WebView
+    - \.proceed\(\);
   severity: ERROR
   input_case: exact
   metadata:
@@ -123,9 +123,9 @@
     be encrypted and written to the database.
   type: RegexAndOr
   pattern:
-  - android\.database\.sqlite
-  - - rawQuery\(
-    - execSQL\(
+    - android\.database\.sqlite
+    - - rawQuery\(
+      - execSQL\(
   severity: WARNING
   input_case: exact
   metadata:
@@ -140,8 +140,8 @@
     input can result in arbitrary code execution.
   type: RegexAnd
   pattern:
-  - com\.fasterxml\.jackson\.databind\.ObjectMapper
-  - \.enableDefaultTyping\(
+    - com\.fasterxml\.jackson\.databind\.ObjectMapper
+    - \.enableDefaultTyping\(
   severity: ERROR
   input_case: exact
   metadata:
@@ -183,8 +183,8 @@
 - id: cbc_kotlin_padding_oracle
   message: The App uses the encryption mode CBC with PKCS5/PKCS7 padding. This configuration is vulnerable to padding oracle attacks.
   pattern:
-  - \.getInstance\(.*\/CBC\/PKCS5Padding
-  - \.getInstance\(.*\/CBC\/PKCS7Padding
+    - \.getInstance\(.*\/CBC\/PKCS5Padding
+    - \.getInstance\(.*\/CBC\/PKCS7Padding
   type: RegexOr
   severity: ERROR
   input_case: exact
@@ -213,8 +213,8 @@
   message: The file is World Writable. Any App can write to the file
   type: RegexOr
   pattern:
-  - MODE_WORLD_WRITABLE
-  - 'openFileOutput\(\s*".+"\s*,\s*2\s*\)'
+    - MODE_WORLD_WRITABLE
+    - 'openFileOutput\(\s*".+"\s*,\s*2\s*\)'
   severity: WARNING
   input_case: exact
   metadata:
@@ -227,8 +227,8 @@
   message: The file is World Readable. Any App can read from the file
   type: RegexOr
   pattern:
-  - MODE_WORLD_READABLE
-  - 'openFileOutput\(\s*".+"\s*,\s*1\s*\)'
+    - MODE_WORLD_READABLE
+    - 'openFileOutput\(\s*".+"\s*,\s*1\s*\)'
   severity: WARNING
   input_case: exact
   metadata:
@@ -252,8 +252,8 @@
 - id: android_kotlin_weak_hash
   message: Weak Hash algorithm used. The hash algorithm is known to have hash collisions.
   pattern:
-  - \.getInstance\(.*md4
-  - \.getInstance\(.*MD4
+    - \.getInstance\(.*md4
+    - \.getInstance\(.*MD4
   type: RegexOr
   input_case: exact
   severity: WARNING
@@ -269,14 +269,14 @@
   type: RegexOr
   input_case: exact
   pattern:
-  - \.getInstance\(.*rc2
-  - \.getInstance\(.*RC2
-  - \.getInstance\(.*rc4
-  - \.getInstance\(.*RC4
-  - \.getInstance\(.*blowfish
-  - \.getInstance\(.*BLOWFISH
-  - Cipher\.getInstance\(.*DES
-  - Cipher\.getInstance\(.*des
+    - \.getInstance\(.*rc2
+    - \.getInstance\(.*RC2
+    - \.getInstance\(.*rc4
+    - \.getInstance\(.*RC4
+    - \.getInstance\(.*blowfish
+    - \.getInstance\(.*BLOWFISH
+    - Cipher\.getInstance\(.*DES
+    - Cipher\.getInstance\(.*des
   metadata:
     cwe: cwe-327
     masvs: crypto-4
@@ -287,9 +287,9 @@
   message: MD5 is a weak hash known to have hash collisions.
   type: RegexOr
   pattern:
-  - \.getInstance\(.*MD5
-  - \.getInstance\(.*md5
-  - DigestUtils\.md5\(
+    - \.getInstance\(.*MD5
+    - \.getInstance\(.*md5
+    - DigestUtils\.md5\(
   input_case: exact
   severity: WARNING
   metadata:
@@ -304,11 +304,11 @@
   input_case: exact
   severity: WARNING
   pattern:
-  - \.getInstance\(.*SHA-1
-  - \.getInstance\(.*sha-1
-  - \.getInstance\(.*SHA1
-  - \.getInstance\(.*sha1
-  - DigestUtils\.sha\(
+    - \.getInstance\(.*SHA-1
+    - \.getInstance\(.*sha-1
+    - \.getInstance\(.*SHA1
+    - \.getInstance\(.*sha1
+    - DigestUtils\.sha\(
   metadata:
     cwe: cwe-327
     masvs: crypto-4
@@ -323,8 +323,8 @@
     attack.
   input_case: exact
   pattern:
-  - '0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00'
-  - '0x01,0x02,0x03,0x04,0x05,0x06,0x07'
+    - '0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00'
+    - '0x01,0x02,0x03,0x04,0x05,0x06,0x07'
   severity: WARNING
   type: RegexOr
   metadata:

--- a/mobsfscan/rules/patterns/android/kotlin/kotlin_rules.yaml
+++ b/mobsfscan/rules/patterns/android/kotlin/kotlin_rules.yaml
@@ -29,7 +29,7 @@
     owasp-mobile: m3
     masvs: network-3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#android-network-apis
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: android_kotlin_webview_external
   message: >-
     WebView load files from external storage. Files in external storage can be
@@ -45,7 +45,7 @@
     owasp-mobile: m1
     masvs: platform-6
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#static-analysis-7
-    security-severity: 9.8
+    security-severity: "9.8"
 - id: android_kotlin_insecure_random
   message: The App uses an insecure Random Number Generator.
   type: Regex
@@ -57,7 +57,7 @@
     owasp-mobile: m5
     masvs: crypto-6
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#weak-random-number-generators
-    security-severity: 8.8
+    security-severity: "8.8"
 - id: android_kotlin_logging
   message: The App logs information. Sensitive information should never be logged.
   type: Regex
@@ -69,7 +69,7 @@
     owasp-mobile: m1
     masvs: storage-3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#logs
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: android_kotlin_webview
   message: >-
     Insecure WebView Implementation. Execution of user controlled code in
@@ -85,7 +85,7 @@
     owasp-mobile: m1
     masvs: platform-7
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#testing-javascript-execution-in-webviews-mstg-platform-5
-    security-severity: 9.8
+    security-severity: "9.8"
 - id: android_kotlin_webview_debug
   message: Remote WebView debugging is enabled.
   type: RegexAnd
@@ -99,7 +99,7 @@
     owasp-mobile: m1
     masvs: resilience-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md#testing-anti-debugging-detection-mstg-resilience-2
-    security-severity: 7.2
+    security-severity: "7.2"
 - id: android_kotlin_webview_ignore_ssl
   message: >-
     Insecure WebView Implementation. WebView ignores SSL Certificate errors and
@@ -115,7 +115,7 @@
     owasp-mobile: m3
     masvs: network-3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#webview-server-certificate-verification
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: android_kotlin_sql_raw_query
   message: >-
     App uses SQLite Database and execute raw SQL query. Untrusted user input in
@@ -133,7 +133,7 @@
     owasp-mobile: m7
     masvs: platform-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04h-Testing-Code-Quality.md#injection-flaws-mstg-arch-2-and-mstg-platform-2
-    security-severity: 9.8
+    security-severity: "9.8"
 - id: android_kotlin_jackson_deserialize
   message: >-
     The app uses jackson deserialization library. Deserialization of untrusted
@@ -149,7 +149,7 @@
     owasp-mobile: m7
     masvs: platform-8
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#testing-object-persistence-mstg-platform-8
-    security-severity: 9.8
+    security-severity: "9.8"
 - id: android_kotlin_aes_ecb
   message: >-
     The App uses ECB mode in Cryptographic encryption algorithm. ECB mode is
@@ -164,7 +164,7 @@
     owasp-mobile: m5
     masvs: crypto-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#weak-block-cipher-mode
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: android_kotlin_aes_ecb_default
   message: >-
     Calling Cipher.getInstance("AES") will return AES ECB mode by default. ECB mode is
@@ -179,7 +179,7 @@
     owasp-mobile: m5
     masvs: crypto-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#weak-block-cipher-mode
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: cbc_kotlin_padding_oracle
   message: The App uses the encryption mode CBC with PKCS5/PKCS7 padding. This configuration is vulnerable to padding oracle attacks.
   pattern:
@@ -193,7 +193,7 @@
     owasp-mobile: m5
     cwe: cwe-649
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
-    security-severity: 6.4
+    security-severity: "6.4"
 - id: android_kotlin_rsa_no_oaep
   message: >-
     This App uses RSA Crypto without OAEP padding. The purpose of the padding
@@ -208,7 +208,7 @@
     owasp-mobile: m5
     masvs: crypto-3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#mobile-app-cryptography
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: android_kotlin_world_writable
   message: The file is World Writable. Any App can write to the file
   type: RegexOr
@@ -222,7 +222,7 @@
     owasp-mobile: m2
     masvs: storage-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#testing-local-storage-for-sensitive-data-mstg-storage-1-and-mstg-storage-2
-    security-severity: 7.8
+    security-severity: "7.8"
 - id: android_kotlin_world_readable
   message: The file is World Readable. Any App can read from the file
   type: RegexOr
@@ -236,7 +236,7 @@
     owasp-mobile: m2
     masvs: storage-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#testing-local-storage-for-sensitive-data-mstg-storage-1-and-mstg-storage-2
-    security-severity: 7.8
+    security-severity: "7.8"
 - id: android_kotlin_world_read_write
   message: The file is World Readable and Writable. Any App can read/write to the file
   type: Regex
@@ -248,7 +248,7 @@
     owasp-mobile: m2
     masvs: storage-2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#testing-local-storage-for-sensitive-data-mstg-storage-1-and-mstg-storage-2
-    security-severity: 7.8
+    security-severity: "7.8"
 - id: android_kotlin_weak_hash
   message: Weak Hash algorithm used. The hash algorithm is known to have hash collisions.
   pattern:
@@ -262,7 +262,7 @@
     owasp-mobile: m5
     cwe: cwe-327
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: android_kotlin_weak_ciphers
   message: Weak Encryption algorithm used
   severity: ERROR
@@ -282,7 +282,7 @@
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: android_kotlin_md5
   message: MD5 is a weak hash known to have hash collisions.
   type: RegexOr
@@ -297,7 +297,7 @@
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: android_kotlin_sha1
   message: SHA-1 is a weak hash known to have hash collisions.
   type: RegexOr
@@ -314,7 +314,7 @@
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: android_kotlin_weak_iv
   message: >-
     The App may use weak IVs like "0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00" or
@@ -332,7 +332,7 @@
     masvs: crypto-5
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#mobile-app-cryptography
-    security-severity: 7.5
+    security-severity: "7.5"
 - id: android_kotlin_hardcoded
   message: >-
     Files may contain hardcoded sensitive information like usernames,
@@ -347,4 +347,4 @@
     cwe: cwe-798
     owasp-mobile: m9
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example
-    security-severity: 9.8
+    security-severity: "9.8"

--- a/mobsfscan/rules/patterns/ios/objectivec/best_practices.yaml
+++ b/mobsfscan/rules/patterns/ios/objectivec/best_practices.yaml
@@ -56,7 +56,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-919
-    severity-score:
+    severity-score: ''
     masvs: resilience-1
     owasp-mobile: m8
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#jailbreak-detection-mstg-resilience-1
@@ -71,7 +71,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-919
-    security-severity:
+    security-severity: ''
     masvs: resilience-1
     owasp-mobile: m8
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#jailbreak-detection-mstg-resilience-1
@@ -87,7 +87,7 @@
   metadata:
     masvs: resilience-3
     cwe: cwe-919
-    security-severity:
+    security-severity: ''
     owasp-mobile: m2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#bypassing-jailbreak-detection
 - id: ios_mach_ports
@@ -102,6 +102,6 @@
   metadata:
     masvs: resilience-2
     cwe: cwe-919
-    security-severity:
+    security-severity: ''
     owasp-mobile: m8
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06d-Testing-Data-Storage.md#mach-ports

--- a/mobsfscan/rules/patterns/ios/objectivec/best_practices.yaml
+++ b/mobsfscan/rules/patterns/ios/objectivec/best_practices.yaml
@@ -56,6 +56,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-919
+    severity-score:
     masvs: resilience-1
     owasp-mobile: m8
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#jailbreak-detection-mstg-resilience-1
@@ -70,6 +71,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-919
+    security-severity:
     masvs: resilience-1
     owasp-mobile: m8
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#jailbreak-detection-mstg-resilience-1

--- a/mobsfscan/rules/patterns/ios/objectivec/best_practices.yaml
+++ b/mobsfscan/rules/patterns/ios/objectivec/best_practices.yaml
@@ -87,6 +87,7 @@
   metadata:
     masvs: resilience-3
     cwe: cwe-919
+    security-severity:
     owasp-mobile: m2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#bypassing-jailbreak-detection
 - id: ios_mach_ports
@@ -101,5 +102,6 @@
   metadata:
     masvs: resilience-2
     cwe: cwe-919
+    security-severity:
     owasp-mobile: m8
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06d-Testing-Data-Storage.md#mach-ports

--- a/mobsfscan/rules/patterns/ios/objectivec/objective_c_rules.yaml
+++ b/mobsfscan/rules/patterns/ios/objectivec/objective_c_rules.yaml
@@ -7,7 +7,7 @@
   type: Regex
   metadata:
     cwe: cwe-312
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: storage-14
     owasp-mobile: m9
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#checking-memory-for-sensitive-data-mstg-storage-10
@@ -21,7 +21,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-95
-    security-severity: 9.0
+    security-severity: "9.0"
     masvs: platform-5
     owasp-mobile: m7
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#testing-webview-protocol-handlers-mstg-platform-6
@@ -35,7 +35,7 @@
   type: Regex
   metadata:
     cwe: cwe-676
-    security-severity: 10
+    security-severity: "10"
     masvs: code-8
     owasp-mobile: m7
     reference: https://developer.apple.com/library/archive/documentation/Security/Conceptual/SecureCodingGuide/Articles/BufferOverflows.html#//apple_ref/doc/uid/TP40002577-SW1
@@ -52,7 +52,7 @@
     masvs: network-3
     owasp-mobile: m3
     cwe: cwe-295
-    security-severity: 7.5
+    security-severity: "7.5"
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06g-Testing-Network-Communication.md#testing-custom-certificate-stores-and-certificate-pinning-mstg-network-3-and-mstg-network-4
 - id: ios_webview_ignore_ssl
   message: >-
@@ -67,7 +67,7 @@
     masvs: network-3
     owasp-mobile: m3
     cwe: cwe-295
-    security-severity: 7.5
+    security-severity: "7.5"
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#webview-server-certificate-verification
 - id: ios_app_logging
   message: The App logs information. Sensitive information should never be logged.
@@ -77,7 +77,7 @@
   input_case: exact
   metadata:
     cwe: cwe-532
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: storage-3
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md#finding-debugging-code-and-verbose-error-logging-mstg-code-4
@@ -89,7 +89,7 @@
   type: Regex
   metadata:
     cwe: cwe-311
-    security-severity: 8.1
+    security-severity: "8.1"
     masvs: storage-2
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06d-Testing-Data-Storage.md#ios-data-storage
@@ -103,7 +103,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-327
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
@@ -117,7 +117,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-327
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
@@ -134,7 +134,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-327
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: crypto-3
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#weak-block-cipher-mode

--- a/mobsfscan/rules/patterns/ios/objectivec/objective_c_rules.yaml
+++ b/mobsfscan/rules/patterns/ios/objectivec/objective_c_rules.yaml
@@ -7,6 +7,7 @@
   type: Regex
   metadata:
     cwe: cwe-312
+    security-severity: 7.5
     masvs: storage-14
     owasp-mobile: m9
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#checking-memory-for-sensitive-data-mstg-storage-10
@@ -20,6 +21,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-95
+    security-severity: 9.0
     masvs: platform-5
     owasp-mobile: m7
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#testing-webview-protocol-handlers-mstg-platform-6
@@ -33,6 +35,7 @@
   type: Regex
   metadata:
     cwe: cwe-676
+    security-severity: 10
     masvs: code-8
     owasp-mobile: m7
     reference: https://developer.apple.com/library/archive/documentation/Security/Conceptual/SecureCodingGuide/Articles/BufferOverflows.html#//apple_ref/doc/uid/TP40002577-SW1
@@ -49,6 +52,7 @@
     masvs: network-3
     owasp-mobile: m3
     cwe: cwe-295
+    security-severity: 7.5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06g-Testing-Network-Communication.md#testing-custom-certificate-stores-and-certificate-pinning-mstg-network-3-and-mstg-network-4
 - id: ios_webview_ignore_ssl
   message: >-
@@ -63,6 +67,7 @@
     masvs: network-3
     owasp-mobile: m3
     cwe: cwe-295
+    security-severity: 7.5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#webview-server-certificate-verification
 - id: ios_app_logging
   message: The App logs information. Sensitive information should never be logged.
@@ -72,6 +77,7 @@
   input_case: exact
   metadata:
     cwe: cwe-532
+    security-severity: 7.5
     masvs: storage-3
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md#finding-debugging-code-and-verbose-error-logging-mstg-code-4
@@ -83,6 +89,7 @@
   type: Regex
   metadata:
     cwe: cwe-311
+    security-severity: 8.1
     masvs: storage-2
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06d-Testing-Data-Storage.md#ios-data-storage
@@ -96,6 +103,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-327
+    security-severity: 7.5
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
@@ -109,6 +117,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-327
+    security-severity: 7.5
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
@@ -125,6 +134,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-327
+    security-severity: 7.5
     masvs: crypto-3
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#weak-block-cipher-mode
@@ -136,6 +146,7 @@
   type: Regex
   metadata:
     cwe: cwe-919
+    security-severity: 
     masvs: auth-8
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06f-Testing-Local-Authentication.md#local-authentication-framework

--- a/mobsfscan/rules/patterns/ios/objectivec/objective_c_rules.yaml
+++ b/mobsfscan/rules/patterns/ios/objectivec/objective_c_rules.yaml
@@ -146,7 +146,7 @@
   type: Regex
   metadata:
     cwe: cwe-919
-    security-severity: 
+    security-severity: ''
     masvs: auth-8
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06f-Testing-Local-Authentication.md#local-authentication-framework

--- a/mobsfscan/rules/patterns/ios/swift/best_practices.yaml
+++ b/mobsfscan/rules/patterns/ios/swift/best_practices.yaml
@@ -56,6 +56,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-919
+    security-score: 
     masvs: resilience-1
     owasp-mobile: m8
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#jailbreak-detection-mstg-resilience-1
@@ -67,6 +68,7 @@
   type: Regex
   metadata:
     cwe: cwe-919
+    security-score:
     masvs: platform-11
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#app-extensions
@@ -82,6 +84,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-919
+    security-score: 
     masvs: storage-5
     owasp-mobile: m2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06d-Testing-Data-Storage.md#finding-sensitive-data-in-the-keyboard-cache-mstg-storage-5
@@ -99,6 +102,7 @@
     owasp-mobile: m9
     masvs: resilience-4
     cwe: cwe-919
+    security-score: 
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#ios-anti-reversing-defenses
 - id: ios_cert_pinning
   message: This app does not have Certificate Pinning implemented in code.
@@ -110,6 +114,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-295
+    security-score: 7.5
     masvs: network-4
     owasp-mobile: m3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#testing-custom-certificate-stores-and-certificate-pinning-mstg-network-4

--- a/mobsfscan/rules/patterns/ios/swift/best_practices.yaml
+++ b/mobsfscan/rules/patterns/ios/swift/best_practices.yaml
@@ -56,7 +56,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-919
-    security-severity: 
+    security-severity: ''
     masvs: resilience-1
     owasp-mobile: m8
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#jailbreak-detection-mstg-resilience-1
@@ -68,7 +68,7 @@
   type: Regex
   metadata:
     cwe: cwe-919
-    security-severity:
+    security-severity: ''
     masvs: platform-11
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#app-extensions
@@ -84,7 +84,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-919
-    security-severity: 
+    security-severity: ''
     masvs: storage-5
     owasp-mobile: m2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06d-Testing-Data-Storage.md#finding-sensitive-data-in-the-keyboard-cache-mstg-storage-5
@@ -102,7 +102,7 @@
     owasp-mobile: m9
     masvs: resilience-4
     cwe: cwe-919
-    security-severity: 
+    security-severity: ''
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#ios-anti-reversing-defenses
 - id: ios_cert_pinning
   message: This app does not have Certificate Pinning implemented in code.

--- a/mobsfscan/rules/patterns/ios/swift/best_practices.yaml
+++ b/mobsfscan/rules/patterns/ios/swift/best_practices.yaml
@@ -56,7 +56,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-919
-    security-score: 
+    security-severity: 
     masvs: resilience-1
     owasp-mobile: m8
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#jailbreak-detection-mstg-resilience-1
@@ -68,7 +68,7 @@
   type: Regex
   metadata:
     cwe: cwe-919
-    security-score:
+    security-severity:
     masvs: platform-11
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#app-extensions
@@ -84,7 +84,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-919
-    security-score: 
+    security-severity: 
     masvs: storage-5
     owasp-mobile: m2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06d-Testing-Data-Storage.md#finding-sensitive-data-in-the-keyboard-cache-mstg-storage-5
@@ -102,7 +102,7 @@
     owasp-mobile: m9
     masvs: resilience-4
     cwe: cwe-919
-    security-score: 
+    security-severity: 
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06j-Testing-Resiliency-Against-Reverse-Engineering.md#ios-anti-reversing-defenses
 - id: ios_cert_pinning
   message: This app does not have Certificate Pinning implemented in code.
@@ -114,7 +114,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-295
-    security-score: 7.5
+    security-severity: "7.5"
     masvs: network-4
     owasp-mobile: m3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#testing-custom-certificate-stores-and-certificate-pinning-mstg-network-4

--- a/mobsfscan/rules/patterns/ios/swift/swift_rules.yaml
+++ b/mobsfscan/rules/patterns/ios/swift/swift_rules.yaml
@@ -7,7 +7,7 @@
   type: Regex
   metadata:
     cwe: cwe-312
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: storage-14
     owasp-mobile: m9
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#checking-memory-for-sensitive-data-mstg-storage-10
@@ -21,7 +21,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-95
-    security-severity: 9.0
+    security-severity: "9.0"
     masvs: platform-5
     owasp-mobile: m7
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#testing-webview-protocol-handlers-mstg-platform-6
@@ -33,7 +33,7 @@
   type: Regex
   metadata:
     cwe: cwe-532
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: storage-3
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md#finding-debugging-code-and-verbose-error-logging-mstg-code-4
@@ -48,7 +48,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-327
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
@@ -68,7 +68,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-327
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
@@ -92,7 +92,7 @@
   type: Regex
   metadata:
     cwe: cwe-311
-    security-severity: 8.1
+    security-severity: "8.1"
     masvs: storage-1
     owasp-mobile: m2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06d-Testing-Data-Storage.md#ios-data-storage
@@ -119,7 +119,7 @@
   type: RegexAndOr
   metadata:
     cwe: cwe-757
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: network-2
     owasp-mobile: m3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04f-Testing-Network-Communication.md#verifying-data-encryption-on-the-network-mstg-network-1-and-mstg-network-2
@@ -133,7 +133,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-757
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: network-2
     owasp-mobile: m3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04f-Testing-Network-Communication.md#verifying-data-encryption-on-the-network-mstg-network-1-and-mstg-network-2
@@ -147,7 +147,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-757
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: network-2
     owasp-mobile: m3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04f-Testing-Network-Communication.md#verifying-data-encryption-on-the-network-mstg-network-1-and-mstg-network-2
@@ -161,7 +161,7 @@
   type: Regex
   metadata:
     cwe: cwe-757
-    security-severity: 7.5
+    security-severity: "7.5"
     masvs: network-2
     owasp-mobile: m3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04f-Testing-Network-Communication.md#verifying-data-encryption-on-the-network-mstg-network-1-and-mstg-network-2

--- a/mobsfscan/rules/patterns/ios/swift/swift_rules.yaml
+++ b/mobsfscan/rules/patterns/ios/swift/swift_rules.yaml
@@ -7,6 +7,7 @@
   type: Regex
   metadata:
     cwe: cwe-312
+    security-severity: 7.5
     masvs: storage-14
     owasp-mobile: m9
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#checking-memory-for-sensitive-data-mstg-storage-10
@@ -20,6 +21,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-95
+    security-severity: 9.0
     masvs: platform-5
     owasp-mobile: m7
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#testing-webview-protocol-handlers-mstg-platform-6
@@ -31,6 +33,7 @@
   type: Regex
   metadata:
     cwe: cwe-532
+    security-severity: 7.5
     masvs: storage-3
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06i-Testing-Code-Quality-and-Build-Settings.md#finding-debugging-code-and-verbose-error-logging-mstg-code-4
@@ -45,6 +48,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-327
+    security-severity: 7.5
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
@@ -64,6 +68,7 @@
   type: RegexOr
   metadata:
     cwe: cwe-327
+    security-severity: 7.5
     masvs: crypto-4
     owasp-mobile: m5
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#identifying-insecure-andor-deprecated-cryptographic-algorithms-mstg-crypto-4
@@ -75,6 +80,7 @@
   type: Regex
   metadata:
     cwe: cwe-919
+    security-severity:
     masvs: auth-8
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06f-Testing-Local-Authentication.md#local-authentication-framework
@@ -86,6 +92,7 @@
   type: Regex
   metadata:
     cwe: cwe-311
+    security-severity: 8.1
     masvs: storage-1
     owasp-mobile: m2
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06d-Testing-Data-Storage.md#ios-data-storage
@@ -97,6 +104,7 @@
   type: Regex
   metadata:
     cwe: cwe-919
+    security-severity:
     masvs: platform-4
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#uipasteboard
@@ -111,6 +119,7 @@
   type: RegexAndOr
   metadata:
     cwe: cwe-757
+    security-severity: 7.5
     masvs: network-2
     owasp-mobile: m3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04f-Testing-Network-Communication.md#verifying-data-encryption-on-the-network-mstg-network-1-and-mstg-network-2
@@ -124,6 +133,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-757
+    security-severity: 7.5
     masvs: network-2
     owasp-mobile: m3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04f-Testing-Network-Communication.md#verifying-data-encryption-on-the-network-mstg-network-1-and-mstg-network-2
@@ -137,6 +147,7 @@
   type: RegexAnd
   metadata:
     cwe: cwe-757
+    security-severity: 7.5
     masvs: network-2
     owasp-mobile: m3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04f-Testing-Network-Communication.md#verifying-data-encryption-on-the-network-mstg-network-1-and-mstg-network-2
@@ -150,6 +161,7 @@
   type: Regex
   metadata:
     cwe: cwe-757
+    security-severity: 7.5
     masvs: network-2
     owasp-mobile: m3
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04f-Testing-Network-Communication.md#verifying-data-encryption-on-the-network-mstg-network-1-and-mstg-network-2
@@ -162,6 +174,7 @@
   input_case: exact
   metadata:
     cwe: cwe-919
+    security-severity:
     masvs: platform-5
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#testing-ios-webviews-mstg-platform-5

--- a/mobsfscan/rules/patterns/ios/swift/swift_rules.yaml
+++ b/mobsfscan/rules/patterns/ios/swift/swift_rules.yaml
@@ -80,7 +80,7 @@
   type: Regex
   metadata:
     cwe: cwe-919
-    security-severity:
+    security-severity: ''
     masvs: auth-8
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06f-Testing-Local-Authentication.md#local-authentication-framework
@@ -104,7 +104,7 @@
   type: Regex
   metadata:
     cwe: cwe-919
-    security-severity:
+    security-severity: ''
     masvs: platform-4
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#uipasteboard
@@ -174,7 +174,7 @@
   input_case: exact
   metadata:
     cwe: cwe-919
-    security-severity:
+    security-severity: ''
     masvs: platform-5
     owasp-mobile: m1
     reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md#testing-ios-webviews-mstg-platform-5

--- a/mobsfscan/rules/semgrep/android/hidden_ui.yaml
+++ b/mobsfscan/rules/semgrep/android/hidden_ui.yaml
@@ -22,7 +22,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-919
-      security-severity: 
+      security-severity: ''
       owasp-mobile: m1
       masvs: storage-7
       reference: >-

--- a/mobsfscan/rules/semgrep/android/hidden_ui.yaml
+++ b/mobsfscan/rules/semgrep/android/hidden_ui.yaml
@@ -22,6 +22,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-919
+      security-severity: 
       owasp-mobile: m1
       masvs: storage-7
       reference: >-

--- a/mobsfscan/rules/semgrep/android/logging.yaml
+++ b/mobsfscan/rules/semgrep/android/logging.yaml
@@ -36,6 +36,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-532
+      security-severity: 7.5
       owasp-mobile: m1
       masvs: storage-3
       reference: >-

--- a/mobsfscan/rules/semgrep/android/logging.yaml
+++ b/mobsfscan/rules/semgrep/android/logging.yaml
@@ -36,7 +36,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-532
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m1
       masvs: storage-3
       reference: >-

--- a/mobsfscan/rules/semgrep/android/secrets.yaml
+++ b/mobsfscan/rules/semgrep/android/secrets.yaml
@@ -18,7 +18,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-798
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m9
       masvs: storage-14
       reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example
@@ -41,7 +41,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-798
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m9
       masvs: storage-14
       reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example
@@ -64,7 +64,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-798
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m9
       masvs: storage-14
       reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example
@@ -87,7 +87,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-798
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m9
       masvs: storage-14
       reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example

--- a/mobsfscan/rules/semgrep/android/secrets.yaml
+++ b/mobsfscan/rules/semgrep/android/secrets.yaml
@@ -18,6 +18,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-798
+      security-severity: 9.8
       owasp-mobile: m9
       masvs: storage-14
       reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example
@@ -40,6 +41,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-798
+      security-severity: 9.8
       owasp-mobile: m9
       masvs: storage-14
       reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example
@@ -62,6 +64,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-798
+      security-severity: 9.8
       owasp-mobile: m9
       masvs: storage-14
       reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example
@@ -84,6 +87,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-798
+      security-severity: 9.8
       owasp-mobile: m9
       masvs: storage-14
       reference: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example

--- a/mobsfscan/rules/semgrep/android/word_readable_writable.yaml
+++ b/mobsfscan/rules/semgrep/android/word_readable_writable.yaml
@@ -10,6 +10,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-276
+      security-severity: 7.8
       owasp-mobile: m2
       masvs: storage-2
       reference: >-
@@ -27,6 +28,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-276
+      security-severity: 7.8
       owasp-mobile: m2
       masvs: storage-2
       reference: >-

--- a/mobsfscan/rules/semgrep/android/word_readable_writable.yaml
+++ b/mobsfscan/rules/semgrep/android/word_readable_writable.yaml
@@ -10,7 +10,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-276
-      security-severity: 7.8
+      security-severity: "7.8"
       owasp-mobile: m2
       masvs: storage-2
       reference: >-
@@ -28,7 +28,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-276
-      security-severity: 7.8
+      security-severity: "7.8"
       owasp-mobile: m2
       masvs: storage-2
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/android_safetynetapi.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/android_safetynetapi.yaml
@@ -20,7 +20,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-353
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m8
       masvs: resilience-1
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/android_safetynetapi.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/android_safetynetapi.yaml
@@ -20,6 +20,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-353
+      security-severity: 7.5
       owasp-mobile: m8
       masvs: resilience-1
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/flag_secure.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/flag_secure.yaml
@@ -36,6 +36,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-200
+      security-severity: 6.5
       owasp-mobile: m2
       masvs: storage-9
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/flag_secure.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/flag_secure.yaml
@@ -36,7 +36,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-200
-      security-severity: 6.5
+      security-severity: "6.5"
       owasp-mobile: m2
       masvs: storage-9
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/root_detection.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/root_detection.yaml
@@ -21,7 +21,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-919
-      security-severity: 
+      security-severity: ''
       owasp-mobile: m8
       masvs: resilience-1
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/root_detection.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/root_detection.yaml
@@ -21,6 +21,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-919
+      security-severity: 
       owasp-mobile: m8
       masvs: resilience-1
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/tapjacking.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/tapjacking.yaml
@@ -13,7 +13,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-200
-      security-severity: 6.5
+      security-severity: "6.5"
       owasp-mobile: m1
       masvs: platform-9
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/tapjacking.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/tapjacking.yaml
@@ -13,6 +13,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-200
+      security-severity: 6.5
       owasp-mobile: m1
       masvs: platform-9
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/tls_certificate_transparency.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/tls_certificate_transparency.yaml
@@ -18,6 +18,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-295
+      security-severity: 7.5
       owasp-mobile: m3
       masvs: network-4
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/tls_certificate_transparency.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/tls_certificate_transparency.yaml
@@ -18,7 +18,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-295
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m3
       masvs: network-4
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/tls_pinning.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/tls_pinning.yaml
@@ -45,6 +45,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-295
+      security-severity: 7.5
       owasp-mobile: m3
       masvs: network-4
       reference: >-

--- a/mobsfscan/rules/semgrep/best_practices/tls_pinning.yaml
+++ b/mobsfscan/rules/semgrep/best_practices/tls_pinning.yaml
@@ -45,7 +45,7 @@ rules:
     severity: INFO
     metadata:
       cwe: cwe-295
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m3
       masvs: network-4
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/aes_ecb.yaml
+++ b/mobsfscan/rules/semgrep/crypto/aes_ecb.yaml
@@ -31,6 +31,7 @@ rules:
       - java
     metadata:
       cwe: cwe-327
+      security-severity: 7.5
       owasp-mobile: m5
       masvs: crypto-2
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/aes_ecb.yaml
+++ b/mobsfscan/rules/semgrep/crypto/aes_ecb.yaml
@@ -31,7 +31,7 @@ rules:
       - java
     metadata:
       cwe: cwe-327
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m5
       masvs: crypto-2
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/aes_encryption_keys.yaml
+++ b/mobsfscan/rules/semgrep/crypto/aes_encryption_keys.yaml
@@ -20,7 +20,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-321
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m5
       masvs: crypto-1
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/aes_encryption_keys.yaml
+++ b/mobsfscan/rules/semgrep/crypto/aes_encryption_keys.yaml
@@ -20,6 +20,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-321
+      security-severity: 7.5
       owasp-mobile: m5
       masvs: crypto-1
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/cbc_padding_oracle.yaml
+++ b/mobsfscan/rules/semgrep/crypto/cbc_padding_oracle.yaml
@@ -22,7 +22,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-649
-      security-severity: 6.4
+      security-severity: "6.4"
       owasp-mobile: m5
       masvs: crypto-3
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/cbc_padding_oracle.yaml
+++ b/mobsfscan/rules/semgrep/crypto/cbc_padding_oracle.yaml
@@ -22,6 +22,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-649
+      security-severity: 6.4
       owasp-mobile: m5
       masvs: crypto-3
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/cbc_static_iv.yaml
+++ b/mobsfscan/rules/semgrep/crypto/cbc_static_iv.yaml
@@ -22,7 +22,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-329
-      security-severity: 7.4
+      security-severity: "7.4"
       owasp-mobile: m5
       masvs: crypto-5
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/cbc_static_iv.yaml
+++ b/mobsfscan/rules/semgrep/crypto/cbc_static_iv.yaml
@@ -22,6 +22,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-329
+      security-severity: 7.4
       owasp-mobile: m5
       masvs: crypto-5
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/insecure_random.yaml
+++ b/mobsfscan/rules/semgrep/crypto/insecure_random.yaml
@@ -12,7 +12,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-330
-      security-severity: 8.8
+      security-severity: "8.8"
       owasp-mobile: m5
       masvs: crypto-6
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/insecure_random.yaml
+++ b/mobsfscan/rules/semgrep/crypto/insecure_random.yaml
@@ -12,6 +12,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-330
+      security-severity: 8.8
       owasp-mobile: m5
       masvs: crypto-6
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/insecure_ssl_v3.yaml
+++ b/mobsfscan/rules/semgrep/crypto/insecure_ssl_v3.yaml
@@ -10,7 +10,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-327
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m5
       masvs: crypto-4
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/insecure_ssl_v3.yaml
+++ b/mobsfscan/rules/semgrep/crypto/insecure_ssl_v3.yaml
@@ -10,6 +10,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-327
+      security-severity: 7.5
       owasp-mobile: m5
       masvs: crypto-4
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/rsa_no_oeap.yaml
+++ b/mobsfscan/rules/semgrep/crypto/rsa_no_oeap.yaml
@@ -18,7 +18,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-780
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m5
       masvs: crypto-3
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/rsa_no_oeap.yaml
+++ b/mobsfscan/rules/semgrep/crypto/rsa_no_oeap.yaml
@@ -18,6 +18,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-780
+      security-severity: 7.5
       owasp-mobile: m5
       masvs: crypto-3
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/sha1_hash.yaml
+++ b/mobsfscan/rules/semgrep/crypto/sha1_hash.yaml
@@ -16,6 +16,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-327
+      security-severity: 7.5
       owasp-mobile: m5
       masvs: crypto-4
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/sha1_hash.yaml
+++ b/mobsfscan/rules/semgrep/crypto/sha1_hash.yaml
@@ -16,7 +16,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-327
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m5
       masvs: crypto-4
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/weak_ciphers.yaml
+++ b/mobsfscan/rules/semgrep/crypto/weak_ciphers.yaml
@@ -14,7 +14,7 @@ rules:
       - java
     metadata:
       cwe: cwe-327
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m5
       masvs: crypto-4
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/weak_ciphers.yaml
+++ b/mobsfscan/rules/semgrep/crypto/weak_ciphers.yaml
@@ -14,6 +14,7 @@ rules:
       - java
     metadata:
       cwe: cwe-327
+      security-severity: 7.5
       owasp-mobile: m5
       masvs: crypto-4
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/weak_hashes.yaml
+++ b/mobsfscan/rules/semgrep/crypto/weak_hashes.yaml
@@ -20,7 +20,7 @@ rules:
       - java
     metadata:
       cwe: cwe-327
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m5
       masvs: crypto-4
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/weak_hashes.yaml
+++ b/mobsfscan/rules/semgrep/crypto/weak_hashes.yaml
@@ -20,6 +20,7 @@ rules:
       - java
     metadata:
       cwe: cwe-327
+      security-severity: 7.5
       owasp-mobile: m5
       masvs: crypto-4
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/weak_iv.yaml
+++ b/mobsfscan/rules/semgrep/crypto/weak_iv.yaml
@@ -24,6 +24,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-1204
+      security-severity: 7.5
       owasp-mobile: m5
       masvs: crypto-5
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/weak_iv.yaml
+++ b/mobsfscan/rules/semgrep/crypto/weak_iv.yaml
@@ -24,7 +24,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-1204
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m5
       masvs: crypto-5
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/weak_key_size.yaml
+++ b/mobsfscan/rules/semgrep/crypto/weak_key_size.yaml
@@ -47,7 +47,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-326
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m5
       masvs: crypto-3
       reference: >-

--- a/mobsfscan/rules/semgrep/crypto/weak_key_size.yaml
+++ b/mobsfscan/rules/semgrep/crypto/weak_key_size.yaml
@@ -47,6 +47,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-326
+      security-severity: 7.5
       owasp-mobile: m5
       masvs: crypto-3
       reference: >-

--- a/mobsfscan/rules/semgrep/deserialization/jackson_deserialization.yaml
+++ b/mobsfscan/rules/semgrep/deserialization/jackson_deserialization.yaml
@@ -16,6 +16,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-502
+      security-severity: 9.8
       owasp-mobile: m1
       masvs: platform-8
       reference: >-

--- a/mobsfscan/rules/semgrep/deserialization/jackson_deserialization.yaml
+++ b/mobsfscan/rules/semgrep/deserialization/jackson_deserialization.yaml
@@ -16,7 +16,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-502
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m1
       masvs: platform-8
       reference: >-

--- a/mobsfscan/rules/semgrep/deserialization/object_deserialization.yaml
+++ b/mobsfscan/rules/semgrep/deserialization/object_deserialization.yaml
@@ -14,7 +14,7 @@ rules:
       transmitting object fields and populating a new object.
     metadata:
       cwe: cwe-502
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m1
       masvs: platform-8
       reference: >-

--- a/mobsfscan/rules/semgrep/deserialization/object_deserialization.yaml
+++ b/mobsfscan/rules/semgrep/deserialization/object_deserialization.yaml
@@ -14,6 +14,7 @@ rules:
       transmitting object fields and populating a new object.
     metadata:
       cwe: cwe-502
+      security-severity: 9.8
       owasp-mobile: m1
       masvs: platform-8
       reference: >-

--- a/mobsfscan/rules/semgrep/injection/command_injection.yaml
+++ b/mobsfscan/rules/semgrep/injection/command_injection.yaml
@@ -12,7 +12,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-78
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m7
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/injection/command_injection.yaml
+++ b/mobsfscan/rules/semgrep/injection/command_injection.yaml
@@ -12,6 +12,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-78
+      security-severity: 9.8
       owasp-mobile: m7
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/injection/command_injection_formated.yaml
+++ b/mobsfscan/rules/semgrep/injection/command_injection_formated.yaml
@@ -50,7 +50,7 @@ rules:
       - java
     metadata:
       cwe: cwe-78
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m7
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/injection/command_injection_formated.yaml
+++ b/mobsfscan/rules/semgrep/injection/command_injection_formated.yaml
@@ -50,6 +50,7 @@ rules:
       - java
     metadata:
       cwe: cwe-78
+      security-severity: 9.8
       owasp-mobile: m7
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/injection/sqlite_injection.yaml
+++ b/mobsfscan/rules/semgrep/injection/sqlite_injection.yaml
@@ -29,6 +29,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-78
+      security-severity: 9.8
       owasp-mobile: m7
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/injection/sqlite_injection.yaml
+++ b/mobsfscan/rules/semgrep/injection/sqlite_injection.yaml
@@ -29,7 +29,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-78
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m7
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/network/accept_self_signed.yaml
+++ b/mobsfscan/rules/semgrep/network/accept_self_signed.yaml
@@ -75,6 +75,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-295
+      security-severity: 7.5
       owasp-mobile: m3
       masvs: network-3
       reference: >-

--- a/mobsfscan/rules/semgrep/network/accept_self_signed.yaml
+++ b/mobsfscan/rules/semgrep/network/accept_self_signed.yaml
@@ -75,7 +75,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-295
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m3
       masvs: network-3
       reference: >-

--- a/mobsfscan/rules/semgrep/network/default_http_client_tls.yaml
+++ b/mobsfscan/rules/semgrep/network/default_http_client_tls.yaml
@@ -13,6 +13,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-757
+      security-severity: 7.5
       owasp-mobile: m3
       masvs: network-2
       reference: >-

--- a/mobsfscan/rules/semgrep/network/default_http_client_tls.yaml
+++ b/mobsfscan/rules/semgrep/network/default_http_client_tls.yaml
@@ -13,7 +13,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-757
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m3
       masvs: network-2
       reference: >-

--- a/mobsfscan/rules/semgrep/webview/webview_debugging.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_debugging.yaml
@@ -16,6 +16,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-489
+      security-severity: 7.2
       owasp-mobile: m1
       masvs: resilience-2
       reference: >-

--- a/mobsfscan/rules/semgrep/webview/webview_debugging.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_debugging.yaml
@@ -16,7 +16,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-489
-      security-severity: 7.2
+      security-severity: "7.2"
       owasp-mobile: m1
       masvs: resilience-2
       reference: >-

--- a/mobsfscan/rules/semgrep/webview/webview_external_storage.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_external_storage.yaml
@@ -24,7 +24,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-749
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m1
       masvs: platform-6
       reference: >-

--- a/mobsfscan/rules/semgrep/webview/webview_external_storage.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_external_storage.yaml
@@ -24,6 +24,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-749
+      security-severity: 9.8
       owasp-mobile: m1
       masvs: platform-6
       reference: >-

--- a/mobsfscan/rules/semgrep/webview/webview_file_access.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_file_access.yaml
@@ -11,6 +11,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-73
+      security-severity: 9.3
       owasp-mobile: m7
       masvs: platform-6
       reference: >-

--- a/mobsfscan/rules/semgrep/webview/webview_file_access.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_file_access.yaml
@@ -11,7 +11,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-73
-      security-severity: 9.3
+      security-severity: "9.3"
       owasp-mobile: m7
       masvs: platform-6
       reference: >-

--- a/mobsfscan/rules/semgrep/webview/webview_ignore_ssl_errors.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_ignore_ssl_errors.yaml
@@ -17,6 +17,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-295
+      security-severity: 7.5
       owasp-mobile: m3
       masvs: network-3
       reference: >-

--- a/mobsfscan/rules/semgrep/webview/webview_ignore_ssl_errors.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_ignore_ssl_errors.yaml
@@ -17,7 +17,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-295
-      security-severity: 7.5
+      security-severity: "7.5"
       owasp-mobile: m3
       masvs: network-3
       reference: >-

--- a/mobsfscan/rules/semgrep/webview/webview_javascript_interface.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_javascript_interface.yaml
@@ -15,6 +15,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-749
+      security-severity: 9.8
       owasp-mobile: m1
       masvs: platform-7
       reference: >-

--- a/mobsfscan/rules/semgrep/webview/webview_javascript_interface.yaml
+++ b/mobsfscan/rules/semgrep/webview/webview_javascript_interface.yaml
@@ -15,7 +15,7 @@ rules:
     severity: WARNING
     metadata:
       cwe: cwe-749
-      security-severity: 9.8
+      security-severity: "9.8"
       owasp-mobile: m1
       masvs: platform-7
       reference: >-

--- a/mobsfscan/rules/semgrep/xxe/xmldecoder_xxe.yaml
+++ b/mobsfscan/rules/semgrep/xxe/xmldecoder_xxe.yaml
@@ -31,7 +31,7 @@ rules:
       - java
     metadata:
       cwe: cwe-611
-      security-severity: 9.1
+      security-severity: "9.1"
       owasp-mobile: m8
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/xxe/xmldecoder_xxe.yaml
+++ b/mobsfscan/rules/semgrep/xxe/xmldecoder_xxe.yaml
@@ -31,6 +31,7 @@ rules:
       - java
     metadata:
       cwe: cwe-611
+      security-severity: 9.1
       owasp-mobile: m8
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/xxe/xmlfactory_external_entities_enabled.yaml
+++ b/mobsfscan/rules/semgrep/xxe/xmlfactory_external_entities_enabled.yaml
@@ -13,7 +13,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-611
-      security-severity: 9.1
+      security-severity: "9.1"
       owasp-mobile: m8
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/xxe/xmlfactory_external_entities_enabled.yaml
+++ b/mobsfscan/rules/semgrep/xxe/xmlfactory_external_entities_enabled.yaml
@@ -13,6 +13,7 @@ rules:
     severity: ERROR
     metadata:
       cwe: cwe-611
+      security-severity: 9.1
       owasp-mobile: m8
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/xxe/xmlfactory_xxe.yaml
+++ b/mobsfscan/rules/semgrep/xxe/xmlfactory_xxe.yaml
@@ -27,6 +27,7 @@ rules:
       - java
     metadata:
       cwe: cwe-611
+      security-severity: 9.1
       owasp-mobile: m8
       masvs: platform-2
       reference: >-

--- a/mobsfscan/rules/semgrep/xxe/xmlfactory_xxe.yaml
+++ b/mobsfscan/rules/semgrep/xxe/xmlfactory_xxe.yaml
@@ -27,7 +27,7 @@ rules:
       - java
     metadata:
       cwe: cwe-611
-      security-severity: 9.1
+      security-severity: "9.1"
       owasp-mobile: m8
       masvs: platform-2
       reference: >-


### PR DESCRIPTION
## Overview

This PR includes changes to support the `security-severity` property of a given code scanning alert. By doing this, a given alert will be assigned a severity of low, medium, high, or critical.

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/107562400/194961478-0513669b-b8db-48bc-ba26-5707574785e7.png">

## Details

To calculate the `security-severity` of an alert, first all the CVEs reported by [the CWE assigned to the given rule](https://cwe.mitre.org/data/index.html) are grouped. Then the 75th percentile of the [CVSS](https://www.first.org/cvss/v3.1/specification-document) score for those CVEs is calculated.

The data files from https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2020.json.gz (replacing 2020 with the years 2004-2020) are used to get a list of CVEs for a CWE. This list is then sorted by score (ascending), and the 75th percentile score of that list is used as the rule `security-severity`. Numerical scores translate to the below severities in the Security tab.

Severity | Score Range
-- | --
None | 0.0
Low | 0.1 – 3.9
Medium | 4.0 – 6.9
High | 7.0 – 8.9
Critical | 9.0 – 10.0

## Notes

In some cases a given CWE does not have any particular CVEs associated with it. This is likely due to the CWE being a parent or reference for others. In particular [CWE-919](https://cwe.mitre.org/data/definitions/919.html) is a commonly referenced CWE in `mobsfscan` rules, but does not have any CVEs associated with it. In this case, a `security-severity` of 6.5 is assigned.

