### PR TITLE
Make mandatory field "filePath" not nullable for sonarqube output

### DIFF
--- a/mobsfscan/formatters/sonarqube.py
+++ b/mobsfscan/formatters/sonarqube.py
@@ -20,7 +20,7 @@ def get_sonarqube_issue(mobsfscan_issue):
         }
         location = {
             'message': issue_data['description'],
-            'filePath': None,
+            'filePath': "",
             'textRange': text_range,
         }
         primary_location = location


### PR DESCRIPTION
Hi!
I'm recreating an [old PR](https://github.com/MobSF/mobsfscan/pull/37) because I'm integrating mobsfscan to my projects and sending the reports to sonarqube.

The issue is that the resulting report is created with nullable filePath field which should not be nullable :
`java.lang.IllegalStateException: Failed to parse report '/path/to/report.json': missing mandatory field 'filePath' in the primary location of the issue.`

Using an empty filePath works just fine.