### PR TITLE
[iOS] Update best_practices.yaml / ios_keyboard_cache with latest SwiftUI changes

### DIFF
--- a/mobsfscan/rules/patterns/ios/swift/best_practices.yaml
+++ b/mobsfscan/rules/patterns/ios/swift/best_practices.yaml
@@ -78,6 +78,8 @@
     - \.autocorrectionType\s*=\s*\.No
     - UITextAutocorrectionTypeNo
     - \.disableAutocorrection\s*\(\s*true\s*\)
+    - \.autocorrectionDisabled\s*\(\s*true\s*\)
+    - \.autocorrectionDisabled\s*\(\)
   severity: INFO
   type: RegexOr
   metadata:

--- a/mobsfscan/rules/patterns/ios/swift/best_practices.yaml
+++ b/mobsfscan/rules/patterns/ios/swift/best_practices.yaml
@@ -79,7 +79,6 @@
     - UITextAutocorrectionTypeNo
     - \.disableAutocorrection\s*\(\s*true\s*\)
     - \.autocorrectionDisabled\s*\(\s*true\s*\)
-    - \.autocorrectionDisabled\s*\(\)
   severity: INFO
   type: RegexOr
   metadata:


### PR DESCRIPTION
`disableAutocorrection` was renamed to `autocorrectionDisabled` in SwiftUI. Updating the configuration to detect it and avoid false-positive warnings