### PR TITLE
Support multiprocessing strategy

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 
 [packages]
 colorama = ">=0.4.5"
-libsast = ">=3.1.4"
+libsast = ">=3.1.5"
 semgrep = "==1.86.0"
 sarif-om = ">=1.0.4"
 jschema-to-python = ">=1.2.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "15dd49bd8704d827989909e2557fe13c729b112b822796d174562e7d598b6971"
+            "sha256": "3ee2d69017c22dcd11d7b18cbe6b6c1bfec540937e085538f1ccf78a543a84e3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -296,12 +296,12 @@
         },
         "libsast": {
             "hashes": [
-                "sha256:991fd9014b0745482150ceb0362059ef8249b0012cde0e44ca8c700b28c1b3bc",
-                "sha256:9a291e560b1481af45b98d7afd3cba6dd443e22ba857593573dae033c0059939"
+                "sha256:473ed79813893bc7bd331b25d15543effb6efa102a02157d6a58879e1178e1e7",
+                "sha256:c20345480f513df41fc93de91a215e0adf39d38325333cb9b2cda7549417d36c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==3.1.4"
+            "version": "==3.1.5"
         },
         "markdown-it-py": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ Requires Python 3.7+
 
 ```bash
 $ mobsfscan
-usage: mobsfscan [-h] [--json] [--sarif] [--sonarqube] [--html] [--type {android,ios,auto}] [-o OUTPUT] [-c CONFIG] [-w] [--no-fail] [-v] [path ...]
+usage: mobsfscan [-h] [--json] [--sarif] [--sonarqube] [--html] [--type {android,ios,auto}]
+                 [-o OUTPUT] [-c CONFIG] [-mp {default,billiard,thread}] [-w] [--no-fail] [-v]
+                 [path ...]
 
 positional arguments:
   path                  Path can be file(s) or directories with source code
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --json                set output format as JSON
   --sarif               set output format as SARIF 2.1.0
@@ -48,6 +50,8 @@ optional arguments:
                         output filename to save the result
   -c CONFIG, --config CONFIG
                         location to .mobsf config file
+  -mp {default,billiard,thread}, --multiprocessing {default,billiard,thread}
+                        optional: specify multiprocessing strategy
   -w, --exit-warning    non zero exit code on warning
   --no-fail             force zero exit code, takes precedence over --exit-warning
   -v, --version         show mobsfscan version

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   args:
     description: |
       positional arguments:
-      path                  Path can be file(s) or directories with source code
+        path                  Path can be file(s) or directories with source code
 
       optional arguments:
         -h, --help            show this help message and exit
@@ -17,11 +17,16 @@ inputs:
         --sarif               set output format as SARIF 2.1.0
         --sonarqube           set output format compatible with SonarQube
         --html                set output format as HTML
+        --type {android,ios,auto}
+                              optional: force android or ios rules explicitly
         -o OUTPUT, --output OUTPUT
                               output filename to save the result
         -c CONFIG, --config CONFIG
-                              Location to .mobsf config file
+                              location to .mobsf config file
+        -mp {default,billiard,thread}, --multiprocessing {default,billiard,thread}
+                              optional: specify multiprocessing strategy
         -w, --exit-warning    non zero exit code on warning
+        --no-fail             force zero exit code, takes precedence over --exit-warning
         -v, --version         show mobsfscan version
     required: true
 

--- a/mobsfscan/__init__.py
+++ b/mobsfscan/__init__.py
@@ -6,7 +6,7 @@ from datetime import datetime
 __title__ = 'mobsfscan'
 __authors__ = 'Ajin Abraham'
 __copyright__ = f'Copyright {datetime.now().year} Ajin Abraham, OpenSecurity'
-__version__ = '0.4.4'
+__version__ = '0.4.5'
 __version_info__ = tuple(int(i) for i in __version__.split('.'))
 __all__ = [
     '__title__',

--- a/mobsfscan/__main__.py
+++ b/mobsfscan/__main__.py
@@ -57,6 +57,10 @@ def main():
     parser.add_argument('-c', '--config',
                         help='location to .mobsf config file',
                         required=False)
+    parser.add_argument('-mp', '--multiprocessing',
+                        help='optional: specify multiprocessing strategy',
+                        choices=['default', 'billiard', 'thread'],
+                        default='default')
     parser.add_argument('-w', '--exit-warning',
                         help='non zero exit code on warning',
                         action='store_true',
@@ -80,6 +84,7 @@ def main():
             is_json,
             args.type,
             args.config,
+            args.multiprocessing,
         ).scan()
         if args.sonarqube:
             sonarqube.sonarqube_output(

--- a/mobsfscan/mobsfscan.py
+++ b/mobsfscan/mobsfscan.py
@@ -21,7 +21,13 @@ logger = init_logger(__name__)
 
 
 class MobSFScan:
-    def __init__(self, paths, json, scan_type='auto', config=False, mp='default') -> None:
+    def __init__(
+            self,
+            paths,
+            json,
+            scan_type='auto',
+            config=False,
+            mp='default') -> None:
         self.scan_type = scan_type
         self.conf = get_config(paths, config)
         self.options = {

--- a/mobsfscan/mobsfscan.py
+++ b/mobsfscan/mobsfscan.py
@@ -21,7 +21,7 @@ logger = init_logger(__name__)
 
 
 class MobSFScan:
-    def __init__(self, paths, json, scan_type='auto', config=False) -> None:
+    def __init__(self, paths, json, scan_type='auto', config=False, mp='default') -> None:
         self.scan_type = scan_type
         self.conf = get_config(paths, config)
         self.options = {
@@ -35,6 +35,7 @@ class MobSFScan:
             'ignore_rules': self.conf['ignore_rules'],
             'severity_filter': self.conf['severity_filter'],
             'show_progress': not json,
+            'multiprocessing': mp,
         }
         self.paths = paths
         self.result = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ jschema-to-python==1.2.3
 jsonpickle==4.0.0
 jsonschema==4.23.0
 jsonschema-specifications==2024.10.1
-libsast==3.1.4
+libsast==3.1.5
 markdown-it-py==3.0.0
 mdurl==0.1.2
 opentelemetry-api==1.25.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     long_description_content_type='text/markdown',
     install_requires=[
         'colorama>=0.4.5',
-        'libsast>=3.1.0',
+        'libsast>=3.1.5',
         'semgrep==1.86.0',
         'sarif-om>=1.0.4',
         'jschema-to-python>=1.2.3',


### PR DESCRIPTION
Support multiprocessing strategy.

Multiprocessing has issues in AWS Lambda and with Python task Queues such as Celery and Django-Q.
Allow to choose between `ProcessPoolExecutor`, `ThreadPoolExecutor` and `billiard`