### PR TITLE
Removing resolve absolute path of XML files

### DIFF
--- a/mobsfscan/manifest.py
+++ b/mobsfscan/manifest.py
@@ -75,7 +75,7 @@ def scan_manifest(xml_paths, validate_func):
             logger.warning('Failed to parse XML: %s', xml_path)
         if p:
             findings = do_checks(
-                xml_path.resolve().as_posix(), p)
+                xml_path.as_posix(), p)
             if findings:
                 results.extend(findings)
     return mobsfscan_format(results)


### PR DESCRIPTION
Hi @ajinabraham!

When scanning XML files (manifests, etc), absolute paths are reported, not relative paths from the tool's start location

As a result, without additional normalization on the report receiver side (Vulnerability Managers, ASOC, etc) duplicates start to accumulate under certain circumstances