### PR TITLE
oidc publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,3 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
 name: Upload Python Package
 
 on:
@@ -9,23 +6,26 @@ on:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write  # Required for OIDC trusted publishing
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.9, '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,53 +1,124 @@
 name: Build
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 env:
   SEMGREP_R2C_INTERNAL_EXPLICIT_SEMGREPIGNORE: ./tests/assets/src/.semgrepignore
 
 jobs:
-  build:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12']
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-
+        python-version: '3.12'
+        cache: 'pip'
+    
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox semgrep==0.117.0
+        pip install "packaging>=22.0"
+        pip install tox
+    
+    - name: Run linting
+      run: tox -e lint
 
-    - name: Lint
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+    
+    - name: Install dependencies
       run: |
-        tox -e lint
+        python -m pip install --upgrade pip
+        pip install tox
+    
+    - name: Run Bandit
+      run: tox -e bandit
 
-    - name: Bandit
+  semgrep:
+    name: Semgrep Analysis
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+    
+    - name: Install Semgrep
+      run: pip install semgrep==0.117.0
+    
+    - name: Validate Semgrep rules
+      run: semgrep --validate --strict --config=./mobsfscan/rules/semgrep/
+    
+    - name: Test Semgrep rules
       run: |
-        tox -e bandit
+        SEMGREP_SETTINGS_FILE=/dev/null semgrep --metrics=off --test \
+          --config ./mobsfscan/rules/semgrep/ \
+          ./tests/assets/rules/semgrep/
 
-    - name: Semgrep validate rules
+  test:
+    name: Test - Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    
+    - name: Install dependencies
       run: |
-        semgrep --validate --strict --config=./mobsfscan/rules/semgrep/
-
-    - name: Semgrep tests
-      run: |
-        SEMGREP_SETTINGS_FILE=/dev/null semgrep --metrics=off --test --config ./mobsfscan/rules/semgrep/ ./tests/assets/rules/semgrep/
-
+        python -m pip install --upgrade pip
+        pip install "packaging>=22.0"
+        pip install tox
+    
     - name: Run tests
-      run: |
-        tox -e py
+      run: tox -e py
+    
+    - name: Clean up
+      if: always()
+      run: tox -e clean
 
-    - name: Clean Up
+  build-status:
+    name: Build Status
+    if: always()
+    needs: [lint, security, semgrep, test]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check build status
       run: |
-        tox -e clean
+        if [[ "${{ needs.lint.result }}" != "success" ]] || \
+           [[ "${{ needs.security.result }}" != "success" ]] || \
+           [[ "${{ needs.semgrep.result }}" != "success" ]] || \
+           [[ "${{ needs.test.result }}" != "success" ]]; then
+          echo "One or more jobs failed"
+          exit 1
+        fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py37, py38, py39
 skipsdist = True
 toxworkdir=.tox-mobsf
 
@@ -27,7 +26,7 @@ deps =
     flake8-docstrings
     flake8-eradicate
     flake8-import-order
-    flake8-logging-format
+    flake8-logging
     flake8-quotes
     flake8-self
     pep8-naming


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly CI/release pipeline changes, but publishing is now handled via OIDC and a new action, so misconfiguration could break releases or change what credentials are used during publish.
> 
> **Overview**
> Switches PyPI release publishing from Twine + username/password secrets to **OIDC trusted publishing**, using `python -m build` and `pypa/gh-action-pypi-publish` with `id-token: write` permissions.
> 
> Modernizes CI by splitting the previous combined workflow into dedicated `lint`, `bandit`, `semgrep`, and matrix `test` jobs, adding `workflow_dispatch`, updating GitHub Action versions, expanding test coverage to Python `3.10`–`3.13`, and adding a final `build-status` aggregator job. Also updates `tox.ini` lint deps by replacing `flake8-logging-format` with `flake8-logging`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8708e32e3a7e6626959caa14a01cda46a032871. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->