### PR TITLE
Migrate PyPI publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,4 @@
 # Publish to PyPI via Trusted Publishing (OIDC) when a GitHub Release is created.
-# Configure the matching Trusted Publisher on PyPI first:
-#   https://pypi.org/manage/project/mobsfscan/settings/publishing/
-#     Owner: MobSF
-#     Repository: mobsfscan
-#     Workflow: publish.yml
-#     Environment: pypi
-# Then create a GitHub Environment named `pypi` (Settings → Environments).
-# After the first successful trusted publish, remove PYPI_USERNAME / PYPI_PASSWORD secrets.
 
 name: Upload Python Package
 
@@ -22,7 +14,7 @@ jobs:
       url: https://pypi.org/p/mobsfscan
     permissions:
       contents: read
-      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+      id-token: write
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,31 +1,44 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# Publish to PyPI via Trusted Publishing (OIDC) when a GitHub Release is created.
+# Configure the matching Trusted Publisher on PyPI first:
+#   https://pypi.org/manage/project/mobsfscan/settings/publishing/
+#     Owner: MobSF
+#     Repository: mobsfscan
+#     Workflow: publish.yml
+#     Environment: pypi
+# Then create a GitHub Environment named `pypi` (Settings → Environments).
+# After the first successful trusted publish, remove PYPI_USERNAME / PYPI_PASSWORD secrets.
 
 name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mobsfscan
+    permissions:
+      contents: read
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
 
     steps:
     - uses: actions/checkout@v5
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: '3.10'
-    - name: Install dependencies
+
+    - name: Install build tools
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        pip install build
+
+    - name: Build package
+      run: python -m build
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Switch `.github/workflows/publish.yml` from `twine` + `PYPI_USERNAME`/`PYPI_PASSWORD` to [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) via `pypa/gh-action-pypi-publish`
- Require `id-token: write` and a GitHub Environment named `pypi`
- Build with `python -m build` instead of `python setup.py sdist bdist_wheel`
- Trigger on `release: published` (skips draft releases)

## Manual setup (required before first release)
1. On PyPI: [mobsfscan → Publishing](https://pypi.org/manage/project/mobsfscan/settings/publishing/) → add Trusted Publisher:
   - Owner: `MobSF`
   - Repository: `mobsfscan`
   - Workflow: `publish.yml`
   - Environment: `pypi`
2. On GitHub: Settings → Environments → create `pypi` (optional protection rules)
3. After the first successful OIDC publish, delete repo secrets `PYPI_USERNAME` and `PYPI_PASSWORD`

## Test plan
- [ ] Confirm PyPI trusted publisher matches this workflow filename/environment
- [ ] Confirm GitHub Environment `pypi` exists
- [ ] Publish a GitHub Release (or dry-run on TestPyPI if preferred) and verify upload succeeds without API token secrets


Made with [Cursor](https://cursor.com)